### PR TITLE
Adjust path so `init` can copy files.

### DIFF
--- a/packages/iniquity/src/commands/init.ts
+++ b/packages/iniquity/src/commands/init.ts
@@ -75,8 +75,8 @@ export class Init implements yargs.CommandModule {
     }
     public handler(argv: yargs.Arguments) {
         if (!argv.help || !argv.version) {
-            copyfiles([path.join(__dirname, "../example/*"), "."], { up: true, all: true }, (err) => {})
-            copyfiles([path.join(__dirname, "../example/.iniquity/*"), ".iniquity"], { up: true, all: true }, (err) => {})
+            copyfiles([path.join(__dirname, "../../../src/example/*"), "."], { up: true, all: true }, (err) => {})
+            copyfiles([path.join(__dirname, "../../../src/example/.iniquity/*"), ".iniquity"], { up: true, all: true }, (err) => {})
 
             console.log("Iniquity system initialized.")
         }


### PR DESCRIPTION
When one runs `iniquity init --name Foo` nothing happens. The reason is because the path that we try to pull the examples in from doesn't exist within the ts dist path.

There's a couple ways to address this, but I wanted to see what others think.